### PR TITLE
change CCP4reader.hpp to CCP4Reader.hpp for case-sensitive systems

### DIFF
--- a/Classes/MolecularViewerViewController.mm
+++ b/Classes/MolecularViewerViewController.mm
@@ -25,7 +25,7 @@
 #import "SettingViewController.h"
 
 #include "GLES.hpp"
-#include "CCP4reader.hpp"
+#include "CCP4Reader.hpp"
 
 @interface MolecularViewerViewController ()
 @property (nonatomic, retain) EAGLContext *context;

--- a/NDKmol/CCP4Reader.cpp
+++ b/NDKmol/CCP4Reader.cpp
@@ -17,7 +17,7 @@
      You should have received a copy of the GNU Lesser General Public License
      along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
-#include "CCP4reader.hpp"
+#include "CCP4Reader.hpp"
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>

--- a/NDKmol/MarchingSquares.hpp
+++ b/NDKmol/MarchingSquares.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 #include "Renderable.hpp"
-#include "CCP4reader.hpp"
+#include "CCP4Reader.hpp"
 
 // FIXME: should inherit Line?
 class MarchingSquares: public Renderable {

--- a/NDKmol/NdkView.cpp
+++ b/NDKmol/NdkView.cpp
@@ -40,7 +40,7 @@
 #include "VBOCylinder.hpp"
 #include "ChemDatabase.hpp"
 #include "Protein.hpp"
-#include "CCP4reader.hpp"
+#include "CCP4Reader.hpp"
 #include "MarchingSquares.hpp"
 #include "View.hpp"
 #include "Debug.hpp"

--- a/NDKmol/VolumeRenderer.hpp
+++ b/NDKmol/VolumeRenderer.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 #include "Renderable.hpp"
-#include "CCP4reader.hpp"
+#include "CCP4Reader.hpp"
 
 // FIXME: should inherit Line?
 class MarchingSquares: public Renderable {


### PR DESCRIPTION
Hi, I've compiled it with GCC on Linux with a few minor changes. One change is for case-sensitive filenames in header includes.
