### PR TITLE
fix typo ccp4in -> ccp4gz

### DIFF
--- a/NDKmol/CCP4Reader.cpp
+++ b/NDKmol/CCP4Reader.cpp
@@ -42,7 +42,7 @@ CCP4file::CCP4file(std::string filename) {
 		if (!ccp4gz) return;
 		gzread(ccp4gz, buf, 56 * 4);
 		if (parseHeader(buf)) {
-			gzseek(ccp4in, 256 * 4 + NSYMBT, SEEK_SET);
+			gzseek(ccp4gz, 256 * 4 + NSYMBT, SEEK_SET);
 			map = (float*)malloc(NCRS[1] * NCRS[2] * NCRS[3] * sizeof(float));
 			if (map) gzread(ccp4gz, map, NCRS[1] * NCRS[2] * NCRS[3] * sizeof(float));
 		}


### PR DESCRIPTION
I also got this:

```
NDKmol/CCP4Reader.cpp: In constructor ‘CCP4file::CCP4file(std::string)’:
NDKmol/CCP4Reader.cpp:45:45: error: cannot convert ‘FILE* {aka _IO_FILE*}’ to ‘gzFile’ for argument ‘1’ to ‘off_t gzseek(gzFile, off_t, int)’
    gzseek(ccp4in, 256 * 4 + NSYMBT, SEEK_SET);

```

I guess because of typo
