### PR TITLE
added #include <cstddef> for NULL

### DIFF
--- a/NDKmol/CylinderGeometry.cpp
+++ b/NDKmol/CylinderGeometry.cpp
@@ -19,6 +19,7 @@
 
 #include "CylinderGeometry.hpp"
 #include <cmath>
+#include <cstddef>
 
 float *CylinderGeometry::vertexBuffer = NULL;
 float *CylinderGeometry::vertexNormalBuffer = NULL;

--- a/NDKmol/SphereGeometry.cpp
+++ b/NDKmol/SphereGeometry.cpp
@@ -19,6 +19,7 @@
 
 #include "SphereGeometry.hpp"
 #include <cmath>
+#include <cstddef>
 
 float *SphereGeometry::vertexBuffer = NULL;
 float *SphereGeometry::vertexNormalBuffer = NULL;


### PR DESCRIPTION
BTW, GCC also warns about `std:fseek` (single `:`) in `NDKmol/CCP4Reader.cpp:33:3`
