### PR TITLE
use delete[] to match new[]

### DIFF
--- a/NDKmol/Renderable.cpp
+++ b/NDKmol/Renderable.cpp
@@ -55,19 +55,19 @@ Renderable::~Renderable() {
     deleteVBO();
     
 	if (vertexBuffer) {
-		delete vertexBuffer;
+		delete [] vertexBuffer;
 		vertexBuffer = NULL;
 	}
 	if (vertexNormalBuffer) {
-		delete vertexNormalBuffer;
+		delete [] vertexNormalBuffer;
 		vertexNormalBuffer = NULL;
 	}
 	if (faceBuffer) {
-		delete faceBuffer;
+		delete [] faceBuffer;
 		faceBuffer = NULL;
 	}
 	if (colorBuffer) {
-		delete colorBuffer;
+		delete [] colorBuffer;
 		colorBuffer = NULL;
 	}
 	for (int i = 0, lim = children.size(); i < lim; i++) {

--- a/NDKmol/RibbonStrip.cpp
+++ b/NDKmol/RibbonStrip.cpp
@@ -176,8 +176,8 @@ void RibbonStrip::initMesh(float *points1, float *points2, std::vector<Color> &c
 	
 	colorBuffer = colorVectorToFloatArray(colors, div * 8);
 	
-	delete points1;
-	delete points2;
+	delete [] points1;
+	delete [] points2;
 }
 
 
@@ -250,6 +250,6 @@ void RibbonStrip::initMesh(float *points1, float *points2, std::vector<Color> &c
 	
 	colorBuffer = colorVectorToFloatArray(colors, div * 2);
 	
-	delete points1;
-	delete points2;
+	delete [] points1;
+	delete [] points2;
 }

--- a/NDKmol/SmoothTube.cpp
+++ b/NDKmol/SmoothTube.cpp
@@ -110,7 +110,7 @@ SmoothTube::SmoothTube(std::vector<Vector3> &_points, std::vector<Color> &colors
 		voffset += circleDiv;
 	}
 
-	free(points);
+	delete [] points;
 
 	vertexBuffer = vertices;
 	colorBuffer = colorVectorToFloatArray(colors, axisDiv * circleDiv);


### PR DESCRIPTION
When I run ndkmol under valgrind I get errors:

    Mismatched free() / delete / delete []

http://valgrind.org/docs/manual/mc-manual.html#mc-manual.rudefn

These mismatches shouldn't matter on Linux, but just to get rid of the messages...