### PR TITLE
avoid in-class members initializers - use constructors instead

### DIFF
--- a/NDKmol/CCP4Reader.cpp
+++ b/NDKmol/CCP4Reader.cpp
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <zlib.h>
 
-CCP4file::CCP4file(std::string filename) {
+CCP4file::CCP4file(std::string filename) : map(NULL) {
 	FILE *ccp4in = std::fopen(filename.c_str(), "rb");
 	if (!ccp4in) return;
 	

--- a/NDKmol/CCP4Reader.hpp
+++ b/NDKmol/CCP4Reader.hpp
@@ -32,7 +32,7 @@ public:
 	Mat16 getMatrix(bool scale);
 	bool parseHeader(unsigned char* header);
 	
-	float* map = NULL;
+	float* map;
 	// These arrays are 1-indexed!!
 	int NCRS[4], NSTART[4], NXYZ[4], MAPCRS[4], ISPG, NSYMBT;
 	float a, b, c, alpha, beta, gamma, AMIN, AMAX, AMEAN, ARMS;

--- a/NDKmol/Renderable.cpp
+++ b/NDKmol/Renderable.cpp
@@ -22,6 +22,8 @@
 #include "math.h"
 
 Renderable::Renderable() {
+	faceVBO = -1; vertexVBO = -1, vertexNormalVBO = -1; colorVBO = -1;
+	nVertices = 0;
 	scalex = 1; scaley = 1; scalez = 1;
 	posx = 0; posy = 0; posz = 0;
 	rot = 0; rotx = 1; roty = 1; rotz = 0;

--- a/NDKmol/Renderable.hpp
+++ b/NDKmol/Renderable.hpp
@@ -27,10 +27,10 @@ class Renderable {
 public:
 	float *vertexBuffer, *colorBuffer, *vertexNormalBuffer;
 	unsigned short *faceBuffer;
-    int faceVBO = -1, vertexVBO = -1, vertexNormalVBO = -1, colorVBO = -1;
+    int faceVBO, vertexVBO, vertexNormalVBO, colorVBO;
     
-	int nFaces = 0; // number of Faces / 3. nFace * 3 (vert/face) * sizeof(short) is the buffer size
-    int nVertices = 0; // number of vertices * 3(x, y, z). nVertices * sizeof(float) is the buffer size
+	int nFaces; // number of Faces / 3. nFace * 3 (vert/face) * sizeof(short) is the buffer size
+    int nVertices; // number of vertices * 3(x, y, z). nVertices * sizeof(float) is the buffer size
 
     float scalex, scaley, scalez;
 	float posx, posy, posz;


### PR DESCRIPTION
I tested compilation on various systems. On Linux RHEL6 with GCC 4.4 this small change made it compile.
(Non-static data member initializers in a class are new in C++11.)
