### PR TITLE
changes to compile NDKmol on Windows with VC++

### DIFF
--- a/NDKmol/GLES.cpp
+++ b/NDKmol/GLES.cpp
@@ -126,3 +126,23 @@ GLuint CreateShader(const GLchar *vs, const GLchar *fs) {
     return prog;
 }
 #endif
+
+#ifdef _WIN32
+PFNGLGENBUFFERSPROC          glGenBuffers = NULL;
+PFNGLBINDBUFFERPROC          glBindBuffer = NULL;
+PFNGLBUFFERDATAPROC          glBufferData = NULL;
+PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer = NULL;
+PFNGLDELETEBUFFERSPROC       glDeleteBuffers = NULL;
+void PrepareGlFunctions() {
+    glGenBuffers = (PFNGLGENBUFFERSPROC)wglGetProcAddress("glGenBuffers");
+    glBindBuffer = (PFNGLBINDBUFFERPROC)wglGetProcAddress("glBindBuffer");
+    glBufferData = (PFNGLBUFFERDATAPROC)wglGetProcAddress("glBufferData");
+    glVertexAttribPointer = (PFNGLVERTEXATTRIBPOINTERPROC)wglGetProcAddress("glVertexAttribPointer");
+    glDeleteBuffers = (PFNGLDELETEBUFFERSPROC)wglGetProcAddress("glDeleteBuffers");
+    if (!glGenBuffers || !glBindBuffer || !glBufferData ||
+            !glVertexAttribPointer || !glDeleteBuffers) {
+        MessageBox(NULL, "Cannot load OpenGL 1.4 functions.", "Sorry", MB_OK);
+        exit(1);
+    }
+}
+#endif

--- a/NDKmol/GLES.hpp
+++ b/NDKmol/GLES.hpp
@@ -37,6 +37,11 @@
 #include <OpenGLES/ES1/gl.h>
 #elif __APPLE__
 #include <OpenGL/gl.h>
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
 #else
 #define GL_GLEXT_PROTOTYPES
 #define EGL_EGLEXT_PROTOTYPES
@@ -69,6 +74,15 @@ extern unsigned int shaderProgram, shaderVertexPosition, shaderVertexNormal;
 extern unsigned int shaderModelViewMatrix, shaderProjectionMatrix, shaderNormalMatrix;
 extern unsigned int shaderVertexColor;
 extern Mat16 currentModelViewMatrix;
+
+#ifdef _WIN32
+extern PFNGLGENBUFFERSPROC          glGenBuffers;
+extern PFNGLBINDBUFFERPROC          glBindBuffer;
+extern PFNGLBUFFERDATAPROC          glBufferData;
+extern PFNGLVERTEXATTRIBPOINTERPROC glVertexAttribPointer;
+extern PFNGLDELETEBUFFERSPROC       glDeleteBuffers;
+void PrepareGlFunctions();
+#endif
 
 #ifndef OPENGL_ES1
 extern const GLchar *vertexShader, *fragmentShader;


### PR DESCRIPTION
On Windows OpenGL function that were not in ver. 1.1 must be accessed using wglGetProcAddress().
PrepareGlFunctions() is called from GLUT program. I'll send separate PR for the changes in GLUT/.